### PR TITLE
added section for using Python logging module

### DIFF
--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -16,6 +16,7 @@ This describes reliable patterns of coding Python Extensions in C. It covers the
    canonical_function
    parsing_arguments
    module_globals
+   logging
 
 
 Indices and tables

--- a/doc/sphinx/source/logging.rst
+++ b/doc/sphinx/source/logging.rst
@@ -1,0 +1,138 @@
+.. highlight:: python
+    :linenothreshold: 10
+
+.. toctree::
+    :maxdepth: 3
+
+=================================
+Logging
+=================================
+
+This presents a recipe for using the Python logging module in C.
+
+We import the module and define C equivalent logging functions that are
+compatible with the `*printf` family.
+
+.. code-block:: c
+
+    #include <Python.h>
+    #include <stdarg.h>
+
+    /* logging levels defined by logging module */
+    enum { INFO, WARNING, ERROR, DEBUG, EXCEPTION };
+
+    /* module globals */
+    static PyObject *logging_import = NULL;
+    static PyObject *logger = NULL;
+
+    /* Get a logger object from the logging module. */
+    static PyObject *py_get_logger(char *logger_name)
+    {
+        PyObject *logger = NULL;
+        PyObject *ret = NULL;
+
+        logger = PyObject_CallMethod(logging_import, "getLogger", "s", logger_name);
+        if (logger == NULL)
+        {
+            const char *err_msg = "failed to call logging.getLogger";
+            PyErr_SetString(PyExc_RuntimeError, err_msg);
+        }
+
+        return logger;
+    }
+
+    /* main interface to logging function */
+    static void py_log_msg(int log_level, char *printf_fmt, ...)
+    {
+        PyObject *log_msg = NULL;
+        va_list fmt_args;
+
+        va_start(fmt_args, printf_fmt);
+        log_msg = PyUnicode_FromFormatV(printf_fmt, fmt_args);
+        va_end(fmt_args);
+
+        if (log_msg == NULL)
+        {
+            /* fail silently. */
+            return;
+        }
+
+        /* call function depending on loglevel */
+        switch (log_level)
+        {
+            case INFO:
+                PyObject_CallMethod(PyLogger, "info", "O", log_msg);
+                break;
+
+            case WARNING:
+                PyObject_CallMethod(PyLogger, "warn", "O", log_msg);
+                break;
+
+            case ERROR:
+                PyObject_CallMethod(PyLogger, "error", "O", log_msg);
+                break;
+
+            case DEBUG:
+                PyObject_CallMethod(PyLogger, "debug", "O", log_msg);
+                break;
+
+            case EXCEPTION:
+                PyObject_CallMethod(PyLogger, "exception", "O", log_msg);
+                break;
+
+            default:
+                break;
+        }
+
+        Py_DECREF(log_msg);
+    }
+
+    /* module initialization function. */
+    PyMODINIT_FUNC PyInit_interface(void)
+    {
+        /* ... define local variables ... */
+
+    try:
+
+        /* ... code to initialise module ... */
+
+        logging_import = PyImport_ImportModule("logging");
+
+        if (!logging_import)
+        {
+            const char *err_msg = "failed to import 'logging'";
+            PyErr_SetString(PyExc_ImportError, err_msg);
+            goto except;
+        }
+
+        logger = py_get_logger("my.module.name");
+
+        if (!logger)
+        {
+            goto except;
+        }
+
+        /* ... more fabulous things ... */
+
+    except:
+
+        /* abnormal cleanup */
+
+        /* cleanup logger references */
+        Py_XDECREF(logging_import);
+        Py_XDECREF(logger);
+        ret = NULL;
+
+    finally:
+
+        /* ... clean up under normal conditions ... */
+    }
+
+To simply use the interface defined in the above function, use it like the `printf` family of functions:
+
+.. code-block:: c
+
+    py_log_msg(WARNING, "error code: %d", 10);
+
+
+


### PR DESCRIPTION
I really like the Python extension pattern docs. This is something I together to demonstrate how to log in an extension.

It is missing a few things:
1. Using logging module as a library requires adding a NullHandler to the logger object incase the application has yet been configured for logging.
2. A logging function which can use python parsed strings and objects for logging in Python aspects (instead of just C).

This logging system has been [implemented here](https://github.com/fgimian/easysnmp/blob/master/easysnmp/interface.c).

The documentation is in draft mode and I haven't actually been able to verify the output in a browser yet, but I created the PR first to see if this is something you may want to include, and if you had any thoughts on how I could improve it.
