### PR TITLE
Fix incorrect macro name

### DIFF
--- a/doc/sphinx/source/simple_example.rst
+++ b/doc/sphinx/source/simple_example.rst
@@ -49,7 +49,7 @@ which will give us access to the whole Python C API (we will use that later on):
 
 .. code-block:: c
 
-    #define PPY_SSIZE_T_CLEAN
+    #define PY_SSIZE_T_CLEAN
     #include "Python.h"
 
     long fibonacci(long index) {


### PR DESCRIPTION
Change `PPY_SSIZE_T_CLEAN` macro name to `PY_SSIZE_T_CLEAN`.